### PR TITLE
[FIX] Teams Adaptive Cards: Move the "actions" outside the body in the payload.

### DIFF
--- a/examples/test_teams.py
+++ b/examples/test_teams.py
@@ -70,7 +70,7 @@ async def send_teams_login():
     )
     msg = TeamsCard(title='✅  Login Form using Teams API')
     msg.addAction(
-        type='Action.Submit', title="Login into NAV", id="LoginVal"
+        type='Action.Submit', title="Login into NAV", data={"id": "LoginVal"}
     )
     msg.addInput(
         id="UserVal", label='Username', is_required=True, errorMessage="Username is required"
@@ -150,6 +150,9 @@ async def send_direct_message():
         label='Password',
         style="Password"
     )
+    msg.addAction(
+        type='Action.Submit', title="Login into NAV", data={"id": "LoginVal"}
+    )
     async with tm as conn:
         result = await conn.send(
             recipient=recipient,
@@ -157,9 +160,41 @@ async def send_direct_message():
         )
     print('RESULT > ', result)
 
+async def send_direct_chat_with_url_action():
+    user = {
+        "name": "Jesus Lara",
+        "account": {
+            "address": "jlara@trocglobal.com"
+        }
+    }
+
+    try:
+        recipient = Actor(**user)
+    except Exception as e:
+        print(f"Error creating recipient: {e.payload}")
+        return
+
+    tm = Teams(as_user=True)
+    msg = TeamsCard(
+        summary="New Lead Notification",
+        text=f"📢 A new lead has been created for **My Store** store. Check the details below:",
+    )
+
+    # Add a link button to the lead details page
+    msg.addAction(
+        type="Action.OpenUrl",
+        title="View Lead Details",
+        url="https://www.trocglobal.com/my_store/lead_details", # fake url
+    )
+
+    async with tm as conn:
+        result = await conn.send(recipient=recipient, message=msg)
+    print("RESULT > ", result)
+
 if __name__ == "__main__":
     # asyncio.run(send_teams_webhook())
-    asyncio.run(send_teams_api())
+    # asyncio.run(send_teams_api())
     # asyncio.run(send_teams_login())
     # asyncio.run(send_message_chat())
-    # asyncio.run(send_direct_message())
+    asyncio.run(send_direct_message())
+    asyncio.run(send_direct_chat_with_url_action())

--- a/notify/models.py
+++ b/notify/models.py
@@ -254,6 +254,7 @@ class CardAction(BaseModel):
     type: str = Field(required=False, default=None)
     title: str = Field(required=False, default=None)
     data: dict = Field(required=False, default_factory={})
+    url: str = Field(required=False, default=None)
 
 
 class TeamsCard(BaseModel):
@@ -273,9 +274,14 @@ class TeamsCard(BaseModel):
         return super().__post_init__()
 
     def addAction(self, type: str, title: str, **kwargs):
-        self.actions.append(
-            CardAction(type, title, data=kwargs)
-        )
+        action_data = {
+            "type": type,
+            "title": title,
+            "data": kwargs.get("data", {}),
+            "url": kwargs.get("url", "")
+        }
+
+        self.actions.append(CardAction(**action_data))
 
     def addSection(self, **kwargs):
         section = TeamsSection(**kwargs)
@@ -309,6 +315,7 @@ class TeamsCard(BaseModel):
 
     def to_adaptative(self) -> dict:
         body = []
+        actions = []
         if self.title:
             body.append({
                 "type": "TextBlock",
@@ -341,11 +348,11 @@ class TeamsCard(BaseModel):
             sections.extend(section.to_adaptative() for section in self.sections)
         if self.body_objects:
             body.extend(iter(self.body_objects))
+        
+        
+
         if self.actions:
             actions = [action.to_dict() for action in self.actions]
-            body.append({
-                "actions": actions
-            })
 
         return {
             "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
@@ -355,5 +362,6 @@ class TeamsCard(BaseModel):
             "metadata": {
                 "webUrl": "https://contoso.com/tab"
             },
-            "body": body
+            "body": body,
+            "actions": actions,
         }


### PR DESCRIPTION
[FIX] Teams Adaptive Cards: Move the "actions" outside the body in the payload.

Also allow refactor to allow param for the openUrl Action to work.

The request was returning 400 Bad Request because the "actions" key was being sent inside the body. It must be sent a the same level as body instead.

See the examples on https://adaptivecards.io/explorer/Action.OpenUrl.html

or

See the examples on https://adaptivecards.io/explorer/Action.Submit.html


### Tests
![Screenshot From 2025-01-27 19-35-41](https://github.com/user-attachments/assets/755689d5-89fa-4f22-9b09-27c24ca17f31)
![Screenshot From 2025-01-27 19-53-37](https://github.com/user-attachments/assets/673cd7c6-3286-4581-be2c-e62f40384644)
