### PR TITLE
fix(ci): drop broken apt-get fallback in cibuildwheel BEFORE_ALL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           CIBW_SKIP: "*-musllinux*"
           CIBW_ARCHS_LINUX: x86_64
           CIBW_BUILD_FRONTEND: build
-          CIBW_BEFORE_ALL_LINUX: "yum install -y libmemcached-devel openssl-devel zlib-devel || apt-get update && apt-get install -y libmemcached-dev libssl-dev zlib1g-dev"
+          CIBW_BEFORE_ALL_LINUX: "yum install -y libmemcached-devel openssl-devel zlib-devel"
           CIBW_TEST_SKIP: "*"
         with:
           output-dir: dist


### PR DESCRIPTION
`yum ... || apt-get update && apt-get install` parses as `(yum || apt-get update) && apt-get install` — so apt-get install ran even when yum succeeded, failing with code 127 since the manylinux container has no apt-get. Use yum only (the Linux build container is always yum-based).